### PR TITLE
Allow overriding the default file visibility set by FlysystemFS

### DIFF
--- a/src/Fs.php
+++ b/src/Fs.php
@@ -74,6 +74,11 @@ class Fs extends FlysystemFs
     public string $bucketSelectionMode = 'choose';
 
     /**
+     * @var string Default Object Visibility ('' for default behaviour or 'public' or 'private')
+     */
+    public string $visibility = '';
+
+    /**
      * @inheritdoc
      */
     public function __construct(array $config = [])
@@ -315,5 +320,15 @@ class Fs extends FlysystemFs
         $config['authHttpHandler'] = $handler;
 
         return $config;
+    }
+
+    protected function visibility(): string
+    {
+        if(empty($this->visibility))
+        {
+            return parent::visibility();
+        }
+
+        return $this->visibility;
     }
 }

--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -39,7 +39,7 @@
         toggle: true,
         targetPrefix: '.bsm-'
         }) }}
-    
+
         <div class="bsm-choose{% if fs.bucketSelectionMode == 'manual' %} hidden{% endif %}">
             {{ forms.select({
             id: 'bucket',
@@ -56,7 +56,7 @@
         <div class="bsm-choose{% if fs.bucketSelectionMode == 'manual' %} hidden{% endif %}">
             <div class="spinner hidden"></div>
         </div>
-    
+
         <div class="bsm-manual{% if fs.bucketSelectionMode == 'choose' %} hidden{% endif %} flex-grow">
             {{ forms.autosuggest({
             label: "Bucket"|t('google-cloud'),
@@ -76,6 +76,23 @@
     required: true,
     errors: fs.getErrors('bucket'),
 }, bucketInput) }}
+
+
+<div class="field">
+    <div class="heading">
+        <label for="visibility">{{ "Visibility"|t('google-cloud') }}</label>
+        <div class="instructions">{{ "The default visibility setting to apply to new files."|t('google-cloud') }}</div>
+    </div>
+    {{ forms.select({
+        name: 'visibility',
+        options: [
+        { label: 'Default'|t('google-cloud'), value: '' },
+        { label: 'Public'|t('google-cloud'), value: 'public' },
+        { label: 'Private'|t('google-cloud'), value: 'private' }
+        ],
+        value: fs.visibility,
+    }) }}
+</div>
 
 {{ forms.autosuggestField({
     label: "Subfolder"|t('google-cloud'),

--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -77,23 +77,6 @@
     errors: fs.getErrors('bucket'),
 }, bucketInput) }}
 
-
-<div class="field">
-    <div class="heading">
-        <label for="visibility">{{ "Visibility"|t('google-cloud') }}</label>
-        <div class="instructions">{{ "The default visibility setting to apply to new files."|t('google-cloud') }}</div>
-    </div>
-    {{ forms.select({
-        name: 'visibility',
-        options: [
-        { label: 'Default'|t('google-cloud'), value: '' },
-        { label: 'Public'|t('google-cloud'), value: 'public' },
-        { label: 'Private'|t('google-cloud'), value: 'private' }
-        ],
-        value: fs.visibility,
-    }) }}
-</div>
-
 {{ forms.autosuggestField({
     label: "Subfolder"|t('google-cloud'),
     instructions: "If you want to use a bucket’s subfolder as a fs, specify the path to use here."|t('google-cloud'),
@@ -137,8 +120,19 @@
 
 {{ forms.field({
     label: "Cache Duration"|t('google-cloud'),
-    instructions: "The Cache-Control duration that assets should be uploaded to the cloud with.",
+    instructions: 'The Cache-Control duration that assets should be uploaded with.'|t('google-cloud'),
     id: 'cacheDuration',
 }, cacheInput) }}
+
+{{ forms.selectField({
+    label: 'Visibility'|t('google-cloud'),
+    instructions: 'The default visibility that assets should be uploaded with.'|t('google-cloud'),
+    id: 'visibility',
+    name: 'visibility',
+    errors: fs.getErrors('visibility'),
+    value: fs.visibility,
+    options: fs.getVisibilityOptions(),
+    tip: "If automatic, the value will be determined by whether this filesystem has public URLs."
+}) }}
 
 {% do view.registerAssetBundle("craft\\googlecloud\\GoogleCloudBundle") %}


### PR DESCRIPTION
### Description

Hi everyone, here is a little PR with an addition we have made to the FS in some of our private projects. Allowing us to override the default Object Visibility for new files. 

At this moment the Object Visibility for new files created in the cloud is directly tied with the 'HasUrls' option in the `craft\flysystem\base\FlysystemFs` class

`protected function visibility(): string{ return $this->hasUrls ? Visibility::PUBLIC : Visibility::PRIVATE; }`

However we have use cases where we have a private cloud bucket but we do want to set a URL for the files in our filesystem in Craft. This way we can redirect people who want to access a file from the bucket to a controller where we check authentication and then stream the file to the client. This way we can still use the normal getUrl method in our twig files even though there is no direct URL to the file in question.

At this moment you can already do this with the plugin however uploading a new file in the backend will throw a 500 error as the FileSystem will try and set the Object Visibility to 'Public' which will fail when the bucket is private only. 

No hard feelings if this doesn't seem useful for other people :) Just thought it would be nice to share as we have chosen this route a few times. 