### PR TITLE
Enable uniform bucket level access

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ composer require craftcms/google-cloud
 
 ## Setup
 
-Your Google Cloud bucket must use Google's `Fine grained` (per object) permissions, not `Uniform` (per bucket).
-
+In case your Google Cloud bucket uses Google's `Fine grained` (per object) permissions:
 On the permissions table for the new bucket, grant `Storage Object Viewer` to `allUsers`. The `Storage Admin` role should be granted to the service account the credentials are tied to.
 
 To create a new asset volume for your Google Cloud Storage bucket, go to Settings → Assets, create a new volume, and set the Volume Type setting to “Google Cloud Storage”.
 
 > **Tip:** The Project ID, Bucket, and Subfolder settings can be set to environment variables. See [Environmental Configuration](https://docs.craftcms.com/v3/config/environments.html) in the Craft docs to learn more about that.
+
+In case your Google Cloud bucket uses Uniform bucket-level access, just make sure to set the `Visibility` in your volume settings to `Uniform Bucket-Level Access`.

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -139,7 +139,7 @@ class Fs extends FlysystemFs
             ['value' => '', 'label' => Craft::t('google-cloud', 'Automatic')],
             ['value' => Visibility::PUBLIC, 'label' => Craft::t('google-cloud', 'Public')],
             ['value' => Visibility::PRIVATE, 'label' => Craft::t('google-cloud', 'Private')],
-            ['value' => self::UNIFORM_BUCKET_LEVEL_ACCESS, 'label' => Craft::t('google-cloud', 'Uniform Bucket Level Access')],
+            ['value' => self::UNIFORM_BUCKET_LEVEL_ACCESS, 'label' => Craft::t('google-cloud', 'Uniform Bucket-Level Access')],
         ];
     }
 

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -24,6 +24,7 @@ use Google\Cloud\Storage\StorageClient;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
 use League\Flysystem\GoogleCloudStorage\PortableVisibilityHandler;
+use League\Flysystem\GoogleCloudStorage\UniformBucketLevelAccessVisibility;
 use League\Flysystem\Visibility;
 
 /**
@@ -36,6 +37,9 @@ use League\Flysystem\Visibility;
  */
 class Fs extends FlysystemFs
 {
+
+    public const UNIFORM_BUCKET_LEVEL_ACCESS = 'uniformBucketLevelAccess';
+
     /**
      * @inheritdoc
      */
@@ -135,6 +139,7 @@ class Fs extends FlysystemFs
             ['value' => '', 'label' => Craft::t('google-cloud', 'Automatic')],
             ['value' => Visibility::PUBLIC, 'label' => Craft::t('google-cloud', 'Public')],
             ['value' => Visibility::PRIVATE, 'label' => Craft::t('google-cloud', 'Private')],
+            ['value' => self::UNIFORM_BUCKET_LEVEL_ACCESS, 'label' => Craft::t('google-cloud', 'Uniform Bucket Level Access')],
         ];
     }
 
@@ -253,7 +258,14 @@ class Fs extends FlysystemFs
         $client = static::client($config);
         $bucket = $client->bucket(Craft::parseEnv($this->bucket));
 
-        return new GoogleCloudStorageAdapter($bucket, $this->_subfolder(), new PortableVisibilityHandler('allUsers'));
+        $visibilityHandler = null;
+        if ($this->visibility === self::UNIFORM_BUCKET_LEVEL_ACCESS) {
+            $visibilityHandler = new UniformBucketLevelAccessVisibility();
+        } else {
+            $visibilityHandler = new PortableVisibilityHandler('allUsers');
+        }
+
+        return new GoogleCloudStorageAdapter($bucket, $this->_subfolder(), $visibilityHandler);
     }
 
     /**


### PR DESCRIPTION
### Description
Adds a third option to the visibility field, which enables users to use this plugin in combination with a storage bucket with uniform bucket-level access. An older issue was closed because of missing support by the underlying flysystem library, but support has since been added there: https://github.com/thephpleague/flysystem/pull/1357.


### Related issues
- https://github.com/craftcms/google-cloud/issues/23
